### PR TITLE
Positions logic for time gap between positions and txs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ POOL_PLATFORM=ORCA
 FEATURE_FLAG_OPTIMIZATION=TRUE # Only applies to ORCA.
 
 # Settings for transaction sync. Three sync modes: FULL_RANGE, HISTORICAL, UPDATE. FULL_RANGE updates regardless of ur db state (perfect for initial sync). HISTORICAL updates from lowest block time on ur db till the SYNC_DAYS u specified. UPDATE just syncs latest transactions after ur highest block time from db.
-SYNC_DAYS=1
+SYNC_DAYS=3
 SYNC_MODE=FULL_RANGE
 
 #
@@ -38,9 +38,8 @@ SYNC_MODE=FULL_RANGE
 # The strategy you want the backtest to run. These exist for now: NO_REBALANCE, SIMPLE_REBALANCE. You can create your and inject your own into the backtest!
 STRATEGY=SIMPLE_REBALANCE
 
-# Amounts you will LP into the pool with at the beginning of your backtesting. So if you backtest from Jan 1 2024 with $10k, you must look up the correct prices of token a and b at that point in time.
-TOKEN_A_AMOUNT=0
-TOKEN_B_AMOUNT=0
+# The pool address you will be backtesting.
+POOL_ADDRESS_TO_BACKTEST=your_desired_pool_address
 
-# The range you will initialize your position at the BEGINNNING of backtesting (your strat handles the rest).
-RANGE=200
+# The details for ur specific strat which are parsed in config.
+STRATEGY_DETAILS='{"token_a_amount": 1000000, "token_b_amount": 2000000, "range": 100, "upper_tick": 200, "lower_tick": -200}'

--- a/src/backtester/backtest_utils.rs
+++ b/src/backtester/backtest_utils.rs
@@ -307,8 +307,8 @@ mod tests {
                     // real price (below has to be real code):
                     // amount_in: 4.0 * 135.904,
                     // amount_out: 4.0,
-                    amount_in: 4 * 135904 * 10_u128.pow(6) / 1000, // the 1000 to normalize the price to 135.904
-                    amount_out: 4 * 10_u128.pow(9),
+                    amount_in: 4 * 135904 * 10_u64.pow(6) / 1000, // the 1000 to normalize the price to 135.904
+                    amount_out: 4 * 10_u64.pow(9),
                 }),
             }],
         };
@@ -332,8 +332,8 @@ mod tests {
                     // real price (below has to be real code):
                     // amount_in: 1.0 * 135.904,
                     // amount_out: 1.0,
-                    amount_in: 135904 * 10_u128.pow(6) / 1000, // the 1000 to normalize the price to 135.904
-                    amount_out: 1 * 10_u128.pow(9),
+                    amount_in: 135904 * 10_u64.pow(6) / 1000, // the 1000 to normalize the price to 135.904
+                    amount_out: 1 * 10_u64.pow(9),
                 }),
             },
             10,

--- a/src/backtester/backtest_utils.rs
+++ b/src/backtester/backtest_utils.rs
@@ -42,17 +42,16 @@ pub async fn sync_backwards<T: TransactionRepoTrait>(
     transaction_repo: &T,
     mut liquidity_array: LiquidityArray,
     pool_model: PoolModel,
-    latest_transaction: Option<TransactionModelFromDB>,
+    latest_transaction: TransactionModelFromDB,
     batch_size: i64,
 ) -> Result<(LiquidityArray, i64), SyncError> {
     // Initialize the cursor with the latest tx_id
-    let mut cursor = latest_transaction.clone().map(|tx| tx.tx_id);
+    let mut cursor = Some(latest_transaction.tx_id);
 
     // Initialize lowest_tx_id with the maximum possible i64 value
     let mut lowest_tx_id = i64::MAX;
 
     let swap_data = latest_transaction
-        .unwrap()
         .data
         .to_swap_data()
         .map_err(|e| SyncError::DatabaseError(e.to_string()))?
@@ -222,7 +221,6 @@ mod tests {
             token_a_decimals: 9,
             token_b_decimals: 6,
             tick_spacing: 1,
-            total_liquidity: Some("".to_string()),
             fee_rate: 300, // 0.03%
             last_updated_at: Utc::now(),
         };
@@ -273,7 +271,7 @@ mod tests {
             &mock_repo_1,
             initial_liquidity_array,
             pool_model.clone(),
-            Some(TransactionModelFromDB {
+            TransactionModelFromDB {
                 tx_id: 1,
                 signature: "sig1".to_string(),
                 pool_address: "pool1".to_string(),
@@ -288,7 +286,7 @@ mod tests {
                     amount_in: 5.301077056,
                     amount_out: 718.793826,
                 }),
-            }),
+            },
             10,
         )
         .await;
@@ -329,7 +327,7 @@ mod tests {
             &mock_repo_2,
             final_liquidity_array,
             pool_model,
-            Some(TransactionModelFromDB {
+            TransactionModelFromDB {
                 tx_id: 1,
                 signature: "sig1".to_string(),
                 pool_address: "pool1".to_string(),
@@ -344,7 +342,7 @@ mod tests {
                     amount_in: 135.904,
                     amount_out: 1.0,
                 }),
-            }),
+            },
             10,
         )
         .await;

--- a/src/backtester/backtester.rs
+++ b/src/backtester/backtester.rs
@@ -151,21 +151,10 @@ impl Backtest {
                             .to_swap_data()
                             .map_err(|e| SyncError::ParseError(e.to_string()))?;
 
-                        let is_sell = swap_data.token_in == self.wallet.token_a_addr;
-
-                        // Adjust the amount based on the correct token decimals
-                        let adjusted_amount = if is_sell {
-                            // If selling token A, use token A decimals
-                            swap_data.amount_in as u128
-                                * 10u128.pow(self.wallet.token_a_decimals as u32)
-                        } else {
-                            // If selling token B, use token B decimals
-                            swap_data.amount_in as u128
-                                * 10u128.pow(self.wallet.token_b_decimals as u32)
-                        };
-
-                        self.liquidity_arr
-                            .simulate_swap(U256::from(adjusted_amount), is_sell)?;
+                        self.liquidity_arr.simulate_swap(
+                            U256::from(swap_data.amount_in),
+                            swap_data.token_in == self.wallet.token_a_addr,
+                        )?;
                     }
                     _ => {}
                 }

--- a/src/backtester/liquidity_array.rs
+++ b/src/backtester/liquidity_array.rs
@@ -601,9 +601,6 @@ mod tests {
         let dec_diff = 3;
         let mut array = setup_liquidity_array(price, dec_diff, 5, 5 * 120);
 
-        // Get the total liquidity from the setup
-        let total_liquidity = array.active_liquidity;
-
         // Add Alice's position
         let alice_liquidity = 4_000_000_000_u128;
         array.add_owners_position(

--- a/src/backtester/liquidity_array.rs
+++ b/src/backtester/liquidity_array.rs
@@ -478,7 +478,7 @@ mod tests {
         amount_b: u128,
     ) -> LiquidityArray {
         let mut array = LiquidityArray::new(-30000, 30000, 2, 300);
-        let current_tick = price_to_tick(price as f64, decimal_diff);
+        let current_tick = price_to_tick(price as f64 / 10f64.powi(decimal_diff as i32));
 
         array.current_tick = current_tick;
         array.current_sqrt_price = tick_to_sqrt_price_u256(array.current_tick);
@@ -505,7 +505,7 @@ mod tests {
     fn test_get_upper_and_lower_ticks() {
         let price = 120;
         let dec_diff = 3;
-        let current_tick = price_to_tick(price as f64, 3);
+        let current_tick = price_to_tick(price as f64 / 10f64.powi(dec_diff as i32));
 
         let mut array = setup_liquidity_array(price, dec_diff, 5, 5 * 120);
 
@@ -572,7 +572,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            array.current_tick != price_to_tick(price as f64, dec_diff),
+            array.current_tick != price_to_tick(price as f64 / 10f64.powi(dec_diff as i32)),
             "Swap should have moved current tick."
         );
         assert!(

--- a/src/backtester/liquidity_array.rs
+++ b/src/backtester/liquidity_array.rs
@@ -353,8 +353,6 @@ impl LiquidityArray {
             let step_fee = (remaining_fee * step_amount) / remaining_amount;
             let fee_growth = (step_fee * Q128) / liquidity;
 
-            println!("PRE DECISION IF/ELSE: {} {}", remaining_amount, max_in);
-
             // Stay within the initialized range.
             if remaining_amount <= max_in {
                 let old_sqrt_price = current_sqrt_price;

--- a/src/backtester/liquidity_array.rs
+++ b/src/backtester/liquidity_array.rs
@@ -353,6 +353,8 @@ impl LiquidityArray {
             let step_fee = (remaining_fee * step_amount) / remaining_amount;
             let fee_growth = (step_fee * Q128) / liquidity;
 
+            println!("PRE DECISION IF/ELSE: {} {}", remaining_amount, max_in);
+
             // Stay within the initialized range.
             if remaining_amount <= max_in {
                 let old_sqrt_price = current_sqrt_price;

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,9 +20,6 @@ pub struct AppConfig {
     pub pool_address: String,
     pub strategy: StrategyType,
     pub strategy_details: HashMap<String, serde_json::Value>,
-    pub token_a_amount: u128,
-    pub token_b_amount: u128,
-    pub range: i32,
     pub sync_days: i64,
     pub sync_mode: SyncMode,
     pub pool_address_to_backtest: String,
@@ -65,18 +62,6 @@ impl AppConfig {
             database_url: env::var("DATABASE_URL").context("DATABASE_URL must be set")?,
             pool_address: env::var("POOL_ADDRESS").context("POOL_ADDRESS must be set")?,
             strategy,
-            token_a_amount: env::var("TOKEN_A_AMOUNT")
-                .context("TOKEN_A_AMOUNT must be set")?
-                .parse::<u128>()
-                .context("Failed to parse TOKEN_A_AMOUNT")?,
-            token_b_amount: env::var("TOKEN_B_AMOUNT")
-                .context("TOKEN_B_AMOUNT must be set")?
-                .parse::<u128>()
-                .context("Failed to parse TOKEN_B_AMOUNT")?,
-            range: env::var("RANGE")
-                .context("RANGE must be set")?
-                .parse::<i32>()
-                .context("Failed to parse RANGE")?,
             sync_days: env::var("SYNC_DAYS")
                 .unwrap_or_else(|_| "30".to_string())
                 .parse()
@@ -96,8 +81,8 @@ impl AppConfig {
 
     fn validate_strategy_details(&self) -> Result<()> {
         let required_keys = match self.strategy {
-            StrategyType::NoRebalance => vec!["lower_tick", "upper_tick"],
-            StrategyType::SimpleRebalance => vec!["range"],
+            StrategyType::NoRebalance => vec!["lower_tick", "upper_tick", "token_a_amount", "token_b_amount"],
+            StrategyType::SimpleRebalance => vec!["range", "token_a_amount", "token_b_amount"],
         };
 
         for key in required_keys {

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,7 +17,6 @@ pub async fn initialize_sol_amm_backtester_database(pool: &PgPool) -> Result<()>
             token_a_vault TEXT NOT NULL,
             token_b_vault TEXT NOT NULL,
             tick_spacing SMALLINT NOT NULL,
-            total_liquidity TEXT,
             fee_rate SMALLINT NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             last_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -46,16 +45,16 @@ pub async fn initialize_sol_amm_backtester_database(pool: &PgPool) -> Result<()>
 
         r#"
         CREATE TABLE IF NOT EXISTS positions (
-            address TEXT PRIMARY KEY,
+            id SERIAL PRIMARY KEY,
+            address TEXT NOT NULL,
             pool_address TEXT NOT NULL REFERENCES pools(address),
             liquidity TEXT NOT NULL,
             tick_lower INTEGER NOT NULL,
             tick_upper INTEGER NOT NULL,
+            version INTEGER NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-            last_updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         )
         "#,
-        "CREATE INDEX IF NOT EXISTS idx_positions_pool_address ON positions(pool_address)",
     ];
 
     for statement in statements.iter() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -53,6 +53,7 @@ pub async fn initialize_sol_amm_backtester_database(pool: &PgPool) -> Result<()>
             tick_upper INTEGER NOT NULL,
             version INTEGER NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (address, pool_address, version)
         )
         "#,
     ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ async fn sync_data(config: &AppConfig, days: i64) -> Result<()> {
 
     let positions_repo = PositionsRepo::new(pool.clone());
     let positions_api = PositionsApi::new()?;
-    let positions_service = PositionsService::new(positions_repo.clone(), pool_repo, positions_api);
+    let positions_service = PositionsService::new(positions_repo.clone(), positions_api);
 
     match positions_service
         .fetch_and_store_positions_data(&config.pool_address)
@@ -145,8 +145,6 @@ async fn sync_data(config: &AppConfig, days: i64) -> Result<()> {
         Err(e) => eprintln!("Error syncing transactions: {}", e),
     }
 
-    println!("Transactions synced, time to fill in missing data!");
-
     // Update transactions since not all data can be retrieved during sync. Updates will happen using position_data, to fill in liquidity info.
     let transactions_service = TransactionsService::new(tx_repo, positions_repo);
 
@@ -154,7 +152,7 @@ async fn sync_data(config: &AppConfig, days: i64) -> Result<()> {
         .update_and_fill_transactions(&config.pool_address)
         .await
     {
-        Ok(_f) => println!("Updated txs successfully"),
+        Ok(_) => println!("Updated txs successfully"),
         Err(e) => eprintln!("Error updating txs: {}", e),
     }
 
@@ -179,7 +177,7 @@ async fn run_backtest(config: &AppConfig) -> Result<()> {
 
     let positions_repo = PositionsRepo::new(pool.clone());
     let positions_api = PositionsApi::new()?;
-    let positions_service = PositionsService::new(positions_repo, pool_repo, positions_api);
+    let positions_service = PositionsService::new(positions_repo, positions_api);
 
     let tx_repo = TransactionRepo::new(pool);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,7 @@ use backtester::{
     no_rebalance_strategy::NoRebalanceStrategy,
     simple_rebalance_strategy::SimpleRebalanceStrategy,
 };
-// use backtester::{
-//     backtest_utils::{create_full_liquidity_range, sync_backwards},
-//     backtester::{Backtest, Strategy, Wallet},
-//     simple_rebalance_strategy::SimpleRebalanceStrategy,
-// };
+
 use chrono::{Duration, Utc};
 use config::{AppConfig, StrategyType};
 use dotenv::dotenv;
@@ -141,13 +137,13 @@ async fn sync_data(config: &AppConfig, days: i64) -> Result<()> {
     // Sync transactions
     let end_time = Utc::now();
     let start_time = end_time - Duration::days(config.sync_days);
-    match amm_service
-        .sync_transactions(&config.pool_address, start_time, config.sync_mode.clone())
-        .await
-    {
-        Ok(_f) => println!("Synced transactions successfully"),
-        Err(e) => eprintln!("Error syncing transactions: {}", e),
-    }
+    // match amm_service
+    //     .sync_transactions(&config.pool_address, start_time, config.sync_mode.clone())
+    //     .await
+    // {
+    //     Ok(_f) => println!("Synced transactions successfully"),
+    //     Err(e) => eprintln!("Error syncing transactions: {}", e),
+    // }
 
     println!("Transactions synced, time to fill in missing data!");
 
@@ -196,7 +192,7 @@ async fn run_backtest(config: &AppConfig) -> Result<()> {
         .get_position_data_for_transaction(
             tx_repo.clone(),
             &config.pool_address,
-            latest_transaction.clone().unwrap().block_time_utc,
+            latest_transaction.clone().unwrap(),
         )
         .await?;
 
@@ -214,10 +210,13 @@ async fn run_backtest(config: &AppConfig) -> Result<()> {
     )
     .await?;
 
+    let token_a_amount: u128 = config.get_strategy_detail("token_a_amount")?;
+    let token_b_amount: u128 = config.get_strategy_detail("token_b_amount")?;
+
     let amount_token_a =
-        U256::from(config.token_a_amount * 10_u128.pow(pool_data.token_a_decimals as u32));
+        U256::from(token_a_amount * 10_u128.pow(pool_data.token_a_decimals as u32));
     let amount_token_b =
-        U256::from(config.token_b_amount * 10_u128.pow(pool_data.token_b_decimals as u32));
+        U256::from(token_b_amount * 10_u128.pow(pool_data.token_b_decimals as u32));
 
     let wallet = Wallet {
         token_a_addr: pool_data.token_a_address,

--- a/src/models/pool_model.rs
+++ b/src/models/pool_model.rs
@@ -42,7 +42,6 @@ pub struct PoolModel {
     pub token_a_decimals: i16,
     pub token_b_decimals: i16,
     pub tick_spacing: i16,
-    pub total_liquidity: Option<String>,
     pub fee_rate: i16,
     pub last_updated_at: DateTime<Utc>,
 }
@@ -74,7 +73,6 @@ impl PoolModel {
             token_a_vault,
             token_b_vault,
             tick_spacing,
-            total_liquidity: None,
             fee_rate,
             last_updated_at: chrono::Utc::now(),
         }

--- a/src/models/positions_model.rs
+++ b/src/models/positions_model.rs
@@ -12,7 +12,6 @@ pub struct PositionModel {
     pub tick_lower: i32,
     pub tick_upper: i32,
     pub created_at: DateTime<Utc>,
-    pub last_updated_at: DateTime<Utc>,
 }
 
 // Below is for decoding.
@@ -46,7 +45,6 @@ impl PositionModel {
             tick_lower,
             tick_upper,
             created_at: chrono::Utc::now(),
-            last_updated_at: chrono::Utc::now(),
         }
     }
 }

--- a/src/models/transactions_model.rs
+++ b/src/models/transactions_model.rs
@@ -80,7 +80,7 @@ impl TransactionModel {
 
 impl TransactionModelFromDB {
     pub fn transform_to_tx_model(&self) -> TransactionModel {
-        (TransactionModel {
+        TransactionModel {
             signature: self.signature.clone(),
             pool_address: self.pool_address.clone(),
             block_time: self.block_time,
@@ -88,7 +88,7 @@ impl TransactionModelFromDB {
             transaction_type: self.transaction_type.clone(),
             ready_for_backtesting: self.ready_for_backtesting,
             data: self.data.clone(),
-        })
+        }
     }
 }
 

--- a/src/models/transactions_model.rs
+++ b/src/models/transactions_model.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -40,16 +40,18 @@ pub enum TransactionData {
 pub struct SwapData {
     pub token_in: String,
     pub token_out: String,
-    pub amount_in: u128,
-    pub amount_out: u128,
+    // DB only supports up to 2^64
+    pub amount_in: u64,
+    pub amount_out: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LiquidityData {
     pub token_a: String,
     pub token_b: String,
-    pub amount_a: u128,
-    pub amount_b: u128,
+    // DB only supports up to 2^64
+    pub amount_a: u64,
+    pub amount_b: u64,
     pub liquidity_amount: String,
     pub tick_lower: Option<i32>,
     pub tick_upper: Option<i32>,

--- a/src/models/transactions_model.rs
+++ b/src/models/transactions_model.rs
@@ -40,16 +40,16 @@ pub enum TransactionData {
 pub struct SwapData {
     pub token_in: String,
     pub token_out: String,
-    pub amount_in: f64,
-    pub amount_out: f64,
+    pub amount_in: u128,
+    pub amount_out: u128,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct LiquidityData {
     pub token_a: String,
     pub token_b: String,
-    pub amount_a: f64,
-    pub amount_b: f64,
+    pub amount_a: u128,
+    pub amount_b: u128,
     pub liquidity_amount: String,
     pub tick_lower: Option<i32>,
     pub tick_upper: Option<i32>,

--- a/src/repositories/pool_repo.rs
+++ b/src/repositories/pool_repo.rs
@@ -60,28 +60,6 @@ impl PoolRepo {
         Ok(())
     }
 
-    pub async fn update_liquidity(
-        &self,
-        address: &str,
-        total_liquidity: u128,
-    ) -> Result<(), sqlx::Error> {
-        // Total liquidity stored as string bcos postgres only supports upto i64.
-        query(
-            r#"
-            UPDATE pools
-            SET total_liquidity = $1, last_updated_at = $2
-            WHERE address = $3
-            "#,
-        )
-        .bind(total_liquidity.to_string())
-        .bind(Utc::now())
-        .bind(address)
-        .execute(&self.db)
-        .await?;
-
-        Ok(())
-    }
-
     pub async fn get_pool_by_address(
         &self,
         address: &str,

--- a/src/repositories/positions_repo.rs
+++ b/src/repositories/positions_repo.rs
@@ -34,6 +34,7 @@ impl PositionsRepo {
         transaction: &mut Transaction<'a, Postgres>,
         pool_address: &str,
         position: &PositionModel,
+        version: i32,
     ) -> Result<(), sqlx::Error> {
         sqlx::query(
             r#"
@@ -54,6 +55,7 @@ impl PositionsRepo {
         .bind(position.liquidity.to_string())
         .bind(position.tick_lower)
         .bind(position.tick_upper)
+        .bind(version)
         .bind(position.created_at)
         .execute(transaction)
         .await?;

--- a/src/repositories/transactions_repo.rs
+++ b/src/repositories/transactions_repo.rs
@@ -41,7 +41,7 @@ impl TransactionRepoTrait for TransactionRepo {
             r#"
             SELECT * FROM transactions 
             WHERE pool_address = $1 AND transaction_type = 'Swap'
-            ORDER BY tx_id DESC 
+            ORDER BY block_time DESC, tx_id DESC
             LIMIT 1
             "#,
         )

--- a/src/repositories/transactions_repo.rs
+++ b/src/repositories/transactions_repo.rs
@@ -211,7 +211,11 @@ impl TransactionRepo {
         .bind(last_tx_id)
         .bind(limit)
         .fetch_all(&self.pool)
-        .await?;
+        .await
+        .map_err(|e| {
+            eprintln!("SQL Error: {:?}", e);
+            e
+        })?;
 
         rows.into_iter()
             .map(|row| self.row_to_transaction_model(&row))

--- a/src/services/orca_amm_optimized.rs
+++ b/src/services/orca_amm_optimized.rs
@@ -194,17 +194,17 @@ impl OrcaOptimizedAMM {
         let (amount_in, amount_out) = if is_v2 {
             let transfer0 = payload["transfer0"].as_object().unwrap();
             let transfer1 = payload["transfer1"].as_object().unwrap();
-            
+
             (
                 transfer0["amount"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<u128>()
+                    .parse::<u64>()
                     .unwrap_or(0),
                 transfer1["amount"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<u128>()
+                    .parse::<u64>()
                     .unwrap_or(0),
             )
         } else {
@@ -212,12 +212,12 @@ impl OrcaOptimizedAMM {
                 payload["transferAmount0"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<u128>()
+                    .parse::<u64>()
                     .unwrap_or(0),
                 payload["transferAmount1"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<u128>()
+                    .parse::<u64>()
                     .unwrap_or(0),
             )
         };
@@ -358,13 +358,13 @@ impl OrcaOptimizedAMM {
         let amount_in = payload[amount_in_key]
             .as_str()
             .unwrap_or("0")
-            .parse::<u128>()
+            .parse::<u64>()
             .unwrap_or(0);
 
         let amount_out = payload[amount_out_key]
             .as_str()
             .unwrap_or("0")
-            .parse::<u128>()
+            .parse::<u64>()
             .unwrap_or(0);
 
         let a_to_b = if whirlpool_key == "keyWhirlpoolOne" {
@@ -404,9 +404,9 @@ impl OrcaOptimizedAMM {
         vault_b: &str,
         amount0: &str,
         amount1: &str,
-    ) -> (u128, u128) {
-        let amount0 = amount0.parse::<u128>().unwrap_or(0);
-        let amount1 = amount1.parse::<u128>().unwrap_or(0);
+    ) -> (u64, u64) {
+        let amount0 = amount0.parse::<u64>().unwrap_or(0);
+        let amount1 = amount1.parse::<u64>().unwrap_or(0);
 
         if vault_a == self.token_a_vault {
             (amount0, amount1)

--- a/src/services/orca_amm_optimized.rs
+++ b/src/services/orca_amm_optimized.rs
@@ -190,9 +190,11 @@ impl OrcaOptimizedAMM {
         } else {
             (&self.token_b_address, &self.token_a_address)
         };
+
         let (amount_in, amount_out) = if is_v2 {
             let transfer0 = payload["transfer0"].as_object().unwrap();
             let transfer1 = payload["transfer1"].as_object().unwrap();
+            
             (
                 transfer0["amount"]
                     .as_str()
@@ -219,6 +221,7 @@ impl OrcaOptimizedAMM {
                     .unwrap_or(0.0),
             )
         };
+
         TransactionModel {
             signature: signature.to_string(),
             pool_address: pool_address.to_string(),
@@ -357,6 +360,7 @@ impl OrcaOptimizedAMM {
             .unwrap_or("0")
             .parse::<f64>()
             .unwrap_or(0.0);
+
         let amount_out = payload[amount_out_key]
             .as_str()
             .unwrap_or("0")
@@ -483,6 +487,7 @@ impl AMMService for OrcaOptimizedAMM {
 
             let transaction_models =
                 self.convert_data_to_transactions_model(pool_address, transactions)?;
+
             self.insert_transactions(transaction_models).await?;
 
             // Move to the previous day

--- a/src/services/orca_amm_optimized.rs
+++ b/src/services/orca_amm_optimized.rs
@@ -199,26 +199,26 @@ impl OrcaOptimizedAMM {
                 transfer0["amount"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<f64>()
-                    .unwrap_or(0.0),
+                    .parse::<u128>()
+                    .unwrap_or(0),
                 transfer1["amount"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<f64>()
-                    .unwrap_or(0.0),
+                    .parse::<u128>()
+                    .unwrap_or(0),
             )
         } else {
             (
                 payload["transferAmount0"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<f64>()
-                    .unwrap_or(0.0),
+                    .parse::<u128>()
+                    .unwrap_or(0),
                 payload["transferAmount1"]
                     .as_str()
                     .unwrap_or("0")
-                    .parse::<f64>()
-                    .unwrap_or(0.0),
+                    .parse::<u128>()
+                    .unwrap_or(0),
             )
         };
 
@@ -358,14 +358,14 @@ impl OrcaOptimizedAMM {
         let amount_in = payload[amount_in_key]
             .as_str()
             .unwrap_or("0")
-            .parse::<f64>()
-            .unwrap_or(0.0);
+            .parse::<u128>()
+            .unwrap_or(0);
 
         let amount_out = payload[amount_out_key]
             .as_str()
             .unwrap_or("0")
-            .parse::<f64>()
-            .unwrap_or(0.0);
+            .parse::<u128>()
+            .unwrap_or(0);
 
         let a_to_b = if whirlpool_key == "keyWhirlpoolOne" {
             payload["dataAToBOne"].as_i64().unwrap_or(0) == 1
@@ -404,9 +404,9 @@ impl OrcaOptimizedAMM {
         vault_b: &str,
         amount0: &str,
         amount1: &str,
-    ) -> (f64, f64) {
-        let amount0 = amount0.parse::<f64>().unwrap_or(0.0);
-        let amount1 = amount1.parse::<f64>().unwrap_or(0.0);
+    ) -> (u128, u128) {
+        let amount0 = amount0.parse::<u128>().unwrap_or(0);
+        let amount1 = amount1.parse::<u128>().unwrap_or(0);
 
         if vault_a == self.token_a_vault {
             (amount0, amount1)

--- a/src/services/orca_amm_standard.rs
+++ b/src/services/orca_amm_standard.rs
@@ -148,13 +148,13 @@ impl OrcaStandardAMM {
         json: &Value,
         balance_type: &str,
         pool_address: &str,
-    ) -> Result<(String, f64, String, f64)> {
+    ) -> Result<(String, u128, String, u128)> {
         let balances = json["meta"][balance_type]
             .as_array()
             .ok_or_else(|| anyhow::anyhow!("Missing token balances"))?;
 
-        let mut token_a_amount = 0.0;
-        let mut token_b_amount = 0.0;
+        let mut token_a_amount = 0;
+        let mut token_b_amount = 0;
         let mut token_a_mint = String::new();
         let mut token_b_mint = String::new();
 
@@ -169,16 +169,11 @@ impl OrcaStandardAMM {
                     .ok_or_else(|| anyhow::anyhow!("Missing mint in token balance"))?
                     .to_string();
 
-                let amount = balance["uiTokenAmount"]["uiAmount"]
-                    .as_f64()
-                    .or_else(|| {
-                        balance["uiTokenAmount"]["uiAmountString"]
-                            .as_str()
-                            .and_then(|s| s.parse::<f64>().ok())
-                    })
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Missing or invalid uiAmount in token balance")
-                    })?;
+                let amount = balance["uiTokenAmount"]["amount"]
+                    .as_str()
+                    .ok_or_else(|| anyhow::anyhow!("Missing amount in token balance"))?
+                    .parse::<u128>()
+                    .unwrap_or(0);
 
                 if mint == self.token_a_address {
                     token_a_amount = amount;
@@ -193,16 +188,20 @@ impl OrcaStandardAMM {
         Ok((token_a_mint, token_a_amount, token_b_mint, token_b_amount))
     }
 
-    fn extract_liquidity_amounts(&self, tx_data: &Value, pool_address: &str) -> Result<(f64, f64)> {
+    fn extract_liquidity_amounts(
+        &self,
+        tx_data: &Value,
+        pool_address: &str,
+    ) -> Result<(u128, u128)> {
         let (_, pre_a_amount, _, pre_b_amount) =
             self.get_token_balances(tx_data, "preTokenBalances", pool_address)?;
         let (_, post_a_amount, _, post_b_amount) =
             self.get_token_balances(tx_data, "postTokenBalances", pool_address)?;
 
-        let amount_a = post_a_amount - pre_a_amount;
-        let amount_b = post_b_amount - pre_b_amount;
+        let amount_a = post_a_amount.abs_diff(pre_a_amount);
+        let amount_b = post_b_amount.abs_diff(pre_b_amount);
 
-        Ok((amount_a.abs(), amount_b.abs()))
+        Ok((amount_a, amount_b))
     }
 
     fn convert_liquidity_data(
@@ -285,7 +284,7 @@ impl OrcaStandardAMM {
         &self,
         tx_data: &Value,
         pool_address: &str,
-    ) -> Result<(String, String, f64, f64)> {
+    ) -> Result<(String, String, u128, u128)> {
         let (token_a, pre_a, token_b, pre_b) =
             self.get_token_balances(tx_data, "preTokenBalances", pool_address)?;
         let (_, post_a, _, post_b) =
@@ -296,14 +295,6 @@ impl OrcaStandardAMM {
         } else {
             (token_b, token_a, pre_b - post_b, post_a - pre_a)
         };
-
-        if amount_in <= 0.0 || amount_out <= 0.0 {
-            return Err(anyhow::anyhow!(
-                "Invalid swap amounts: in = {}, out = {}",
-                amount_in,
-                amount_out
-            ));
-        }
 
         Ok((token_in, token_out, amount_in, amount_out))
     }

--- a/src/services/orca_amm_standard.rs
+++ b/src/services/orca_amm_standard.rs
@@ -148,7 +148,7 @@ impl OrcaStandardAMM {
         json: &Value,
         balance_type: &str,
         pool_address: &str,
-    ) -> Result<(String, u128, String, u128)> {
+    ) -> Result<(String, u64, String, u64)> {
         let balances = json["meta"][balance_type]
             .as_array()
             .ok_or_else(|| anyhow::anyhow!("Missing token balances"))?;
@@ -172,7 +172,7 @@ impl OrcaStandardAMM {
                 let amount = balance["uiTokenAmount"]["amount"]
                     .as_str()
                     .ok_or_else(|| anyhow::anyhow!("Missing amount in token balance"))?
-                    .parse::<u128>()
+                    .parse::<u64>()
                     .unwrap_or(0);
 
                 if mint == self.token_a_address {
@@ -192,7 +192,7 @@ impl OrcaStandardAMM {
         &self,
         tx_data: &Value,
         pool_address: &str,
-    ) -> Result<(u128, u128)> {
+    ) -> Result<(u64, u64)> {
         let (_, pre_a_amount, _, pre_b_amount) =
             self.get_token_balances(tx_data, "preTokenBalances", pool_address)?;
         let (_, post_a_amount, _, post_b_amount) =
@@ -284,7 +284,7 @@ impl OrcaStandardAMM {
         &self,
         tx_data: &Value,
         pool_address: &str,
-    ) -> Result<(String, String, u128, u128)> {
+    ) -> Result<(String, String, u64, u64)> {
         let (token_a, pre_a, token_b, pre_b) =
             self.get_token_balances(tx_data, "preTokenBalances", pool_address)?;
         let (_, post_a, _, post_b) =

--- a/src/services/positions_service.rs
+++ b/src/services/positions_service.rs
@@ -35,10 +35,23 @@ impl PositionsService {
             .await
             .context("Failed to start transaction")?;
 
+        // Get the latest version for the pool and increment it
+        let latest_version = self
+            .positions_repo
+            .get_latest_version_for_pool(pool_address)
+            .await
+            .context("Failed to get latest version for pool")?;
+        let new_version = latest_version + 1;
+
         // Upsert positions within the transaction
         for position in positions {
             self.positions_repo
-                .upsert_in_transaction(&mut transaction, pool_address, &position)
+                .upsert_in_transaction(
+                    &mut transaction,
+                    pool_address,
+                    &position,
+                    new_version,
+                )
                 .await
                 .with_context(|| format!("Failed to upsert position: {}", position.address))?;
         }

--- a/src/services/positions_service.rs
+++ b/src/services/positions_service.rs
@@ -1,22 +1,18 @@
 use crate::models::positions_model::PositionModel;
 use crate::models::transactions_model::TransactionModelFromDB;
-use crate::repositories::pool_repo::PoolRepo;
 use crate::repositories::positions_repo::PositionsRepo;
 use crate::{api::positions_api::PositionsApi, repositories::transactions_repo::TransactionRepo};
 use anyhow::{anyhow, Context, Result};
-use chrono::{DateTime, Utc};
 
 pub struct PositionsService {
     positions_repo: PositionsRepo,
-    pool_repo: PoolRepo,
     api: PositionsApi,
 }
 
 impl PositionsService {
-    pub fn new(positions_repo: PositionsRepo, pool_repo: PoolRepo, api: PositionsApi) -> Self {
+    pub fn new(positions_repo: PositionsRepo, api: PositionsApi) -> Self {
         Self {
             positions_repo,
-            pool_repo,
             api,
         }
     }

--- a/src/services/transactions_service.rs
+++ b/src/services/transactions_service.rs
@@ -19,9 +19,10 @@ impl TransactionsService {
     }
 
     pub async fn update_and_fill_transactions(&self, pool_address: &str) -> Result<()> {
+        // any version works, so we pick the first one, since we just need the tick data.
         let position_data = self
             .positions_repo
-            .get_positions_by_pool_address(pool_address)
+            .get_positions_by_pool_address_and_version(pool_address, 0)
             .await
             .context("Failed to get positions by pool address")?;
 

--- a/src/services/transactions_sync_amm_service.rs
+++ b/src/services/transactions_sync_amm_service.rs
@@ -160,6 +160,7 @@ pub async fn create_amm_service(
                 ));
             }
 
+            // test a random url to see if we can use the optimized path.
             let client = reqwest::Client::new();
             let url = format!(
                 "{}/2024/0821/whirlpool-transaction-20240821.jsonl.gz",

--- a/src/utils/hawksight_parsing_tx.rs
+++ b/src/utils/hawksight_parsing_tx.rs
@@ -119,15 +119,15 @@ impl HawksightParser {
 
         // we check the path of a to b and calculate the correct amountin/amountout
         let (amount_in, amount_out) = if swap_data.a_to_b {
-            let amount_b = (swap_data.amount as u128 * price_numerator as u128)
-                / 10_u128.pow(pool_info.decimals_a as u32);
+            let amount_b = (swap_data.amount as u64 * price_numerator as u64)
+                / 10_u64.pow(pool_info.decimals_a as u32);
 
-            (swap_data.amount as u128, amount_b)
+            (swap_data.amount as u64, amount_b)
         } else {
-            let amount_a = (swap_data.amount as u128 * 10_u128.pow(pool_info.decimals_a as u32))
-                / price_numerator as u128;
+            let amount_a = (swap_data.amount as u64 * 10_u64.pow(pool_info.decimals_a as u32))
+                / price_numerator as u64;
 
-            (swap_data.amount as u128, amount_a)
+            (swap_data.amount as u64, amount_a)
         };
 
         let (token_in, token_out) = if swap_data.a_to_b {
@@ -161,7 +161,7 @@ impl HawksightParser {
             if message.starts_with("Program log: Will deposit: ") {
                 let parts: Vec<&str> = message.split_whitespace().collect();
                 if parts.len() >= 6 {
-                    let amount: u128 = parts[4].parse().unwrap_or(0);
+                    let amount: u64 = parts[4].parse().unwrap_or(0);
 
                     // since amount_a is always parsed first, we update that one.
                     if amount_a == 0 {

--- a/src/utils/hawksight_parsing_tx.rs
+++ b/src/utils/hawksight_parsing_tx.rs
@@ -114,18 +114,20 @@ impl HawksightParser {
             })
             .ok_or_else(|| anyhow!("Price numerator not found in logs"))?;
 
-        // price numerator always in terms of token a.
-        let price = (price_numerator as f64) / 10f64.powi(pool_info.decimals_a as i32);
+        // price numerator always in terms of token a (incl decimals)
+        // swap_data.amount is always amount in (either token a or b)
 
         // we check the path of a to b and calculate the correct amountin/amountout
         let (amount_in, amount_out) = if swap_data.a_to_b {
-            let amount_a = swap_data.amount as f64 / 10f64.powi(pool_info.decimals_a as i32);
-            let amount_b = amount_a * price;
-            (amount_a, amount_b)
+            let amount_b = (swap_data.amount as u128 * price_numerator as u128)
+                / 10_u128.pow(pool_info.decimals_a as u32);
+
+            (swap_data.amount as u128, amount_b)
         } else {
-            let amount_b = swap_data.amount as f64 / 10f64.powi(pool_info.decimals_b as i32);
-            let amount_a = amount_b / price;
-            (amount_b, amount_a)
+            let amount_a = (swap_data.amount as u128 * 10_u128.pow(pool_info.decimals_a as u32))
+                / price_numerator as u128;
+
+            (swap_data.amount as u128, amount_a)
         };
 
         let (token_in, token_out) = if swap_data.a_to_b {
@@ -147,8 +149,8 @@ impl HawksightParser {
         pool_info: &PoolInfo,
         account_keys: Vec<String>,
     ) -> Result<LiquidityData> {
-        let mut amount_a = 0.0;
-        let mut amount_b = 0.0;
+        let mut amount_a = 0;
+        let mut amount_b = 0;
 
         let mut tick_lower: Option<i32> = Some(0);
         let mut tick_upper: Option<i32> = Some(0);
@@ -159,11 +161,13 @@ impl HawksightParser {
             if message.starts_with("Program log: Will deposit: ") {
                 let parts: Vec<&str> = message.split_whitespace().collect();
                 if parts.len() >= 6 {
-                    let amount: f64 = parts[4].parse().unwrap_or(0.0);
-                    if amount_a == 0.0 {
-                        amount_a = amount / 10f64.powi(pool_info.decimals_a as i32);
+                    let amount: u128 = parts[4].parse().unwrap_or(0);
+
+                    // since amount_a is always parsed first, we update that one.
+                    if amount_a == 0 {
+                        amount_a = amount;
                     } else {
-                        amount_b = amount / 10f64.powi(pool_info.decimals_b as i32);
+                        amount_b = amount;
                     }
                 }
             } else if message.starts_with("Program log: Tick lower index: ") {
@@ -190,7 +194,7 @@ impl HawksightParser {
             }
         }
 
-        if amount_a == 0.0 || amount_b == 0.0 {
+        if amount_a == 0 || amount_b == 0 {
             return Err(anyhow!("Failed to extract liquidity data from logs"));
         }
 
@@ -296,6 +300,7 @@ mod tests {
             .iter()
             .find(|t| t.transaction_type == "Swap")
             .unwrap();
+
         if let TransactionData::Swap(swap_data) = &swap_transaction.data {
             assert_eq!(
                 swap_data.token_out,
@@ -305,6 +310,9 @@ mod tests {
                 swap_data.token_in,
                 "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
             );
+
+            assert_eq!(swap_data.amount_in, 118566);
+            assert_eq!(swap_data.amount_out, 921);
         } else {
             panic!("Expected Swap data");
         }

--- a/src/utils/price_calcs.rs
+++ b/src/utils/price_calcs.rs
@@ -14,11 +14,8 @@ pub fn tick_to_sqrt_price_u256(tick: i32) -> U256 {
 }
 
 // WORKS GREAT. DO NOT TOUCH. ACCURATE. TESTED AGAINST LIVE SWAPS.
-pub fn price_to_tick(price: f64, decimal_diff: i16) -> i32 {
-    // Step 1: Convert price to sqrtPrice
-    let sqrt_price = (price / 10_f64.powf(decimal_diff as f64)).sqrt();
-
-    let numerator = sqrt_price.ln();
+pub fn price_to_tick(price: f64) -> i32 {
+    let numerator = price.sqrt().ln();
     let denominator = 1.0001f64.ln();
 
     (2.0 * numerator / denominator).floor() as i32
@@ -231,13 +228,16 @@ mod tests {
     #[test]
     fn test_sqrt_price_to_tick() {
         // SOL_USDC
-        assert_eq!(price_to_tick(133.446536f64, 3), -20142);
+        // the nmr is adjusted with decimal diff, since thats how it works when u divide the amounts. SOL real price is 133.44....
+        assert_eq!(price_to_tick(0.133446536f64), -20142);
 
         // SOL/POPCAT
-        assert_eq!(price_to_tick(206.071016394f64, 0), 53284);
+        // 0 token decimal adjustment
+        assert_eq!(price_to_tick(206.071016394f64), 53284);
 
         // SOL/WIF
-        assert_eq!(price_to_tick(86.719236f64, 3), -24453);
+        //3 decimal adjustment, real price is 86.7....
+        assert_eq!(price_to_tick(0.086719236f64), -24453);
     }
 
     #[test]


### PR DESCRIPTION
Since orca optimized sync only gets transactions from 48h ago to the past, we need to make sure that the positions arent overwritten and that there is some historical stuff to use.

Need to test and so on.

Changed in db the amoutns from f64 to u128 since orca optimized only gives amounts with decimals incorporated. bunch of small changes everywhere.

Kind of achieved what i wanted with this PR, found new serious bug.